### PR TITLE
Add WiFi transport and local control via TCP 51515

### DIFF
--- a/custom_components/jura/__init__.py
+++ b/custom_components/jura/__init__.py
@@ -1,19 +1,74 @@
 import logging
+from datetime import timedelta
 
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_interval
 
 from .core import DOMAIN
 from .core.device import Device, EmptyModel, UnsupportedModel, get_machine
+from .core.wifi_device import WifiDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["binary_sensor", "button", "number", "select", "switch", "sensor"]
+# Platforms loaded for BLE entries
+BLE_PLATFORMS = ["binary_sensor", "button", "number", "select", "switch", "sensor"]
+# Platforms loaded for WiFi entries (read-only state sensors only)
+WIFI_PLATFORMS = ["binary_sensor", "sensor"]
+
+WIFI_POLL_INTERVAL = 30  # seconds
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     devices = hass.data.setdefault(DOMAIN, {})
+
+    if entry.data.get("connection_type") == "wifi":
+        return await _setup_wifi_entry(hass, entry, devices)
+
+    return await _setup_ble_entry(hass, entry, devices)
+
+
+async def _setup_wifi_entry(
+    hass: HomeAssistant, entry: ConfigEntry, devices: dict
+) -> bool:
+    """Set up a WiFi-connected Jura machine."""
+    data = entry.data
+    device = WifiDevice(
+        name=entry.title,
+        host=data["host"],
+        port=data.get("port", 51515),
+        pin=data.get("pin", ""),
+        device_name=data.get("device_name", "HomeAssistant"),
+        auth_hash=data.get("auth_hash", ""),
+    )
+    devices[entry.entry_id] = device
+
+    # Initial poll (best-effort; machine may be off)
+    await device.async_update()
+
+    await hass.config_entries.async_forward_entry_setups(entry, WIFI_PLATFORMS)
+
+    async def _poll(_=None):
+        await device.async_update()
+
+    entry.async_on_unload(
+        async_track_time_interval(
+            hass, _poll, timedelta(seconds=WIFI_POLL_INTERVAL)
+        )
+    )
+
+    async def _unload():
+        await device.disconnect()
+
+    entry.async_on_unload(_unload)
+    return True
+
+
+async def _setup_ble_entry(
+    hass: HomeAssistant, entry: ConfigEntry, devices: dict
+) -> bool:
+    """Set up a BLE-connected Jura machine (original behaviour)."""
 
     @callback
     def update_ble(
@@ -45,7 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         device.update_ble(service_info.advertisement)
 
         hass.create_task(
-            hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+            hass.config_entries.async_forward_entry_setups(entry, BLE_PLATFORMS)
         )
 
     # https://developers.home-assistant.io/docs/core/bluetooth/api/
@@ -63,5 +118,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     if entry.entry_id in hass.data[DOMAIN]:
-        await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+        platforms = (
+            WIFI_PLATFORMS
+            if entry.data.get("connection_type") == "wifi"
+            else BLE_PLATFORMS
+        )
+        await hass.config_entries.async_unload_platforms(entry, platforms)
     return True

--- a/custom_components/jura/binary_sensor.py
+++ b/custom_components/jura/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN
-from .core.entity import JuraEntity
+from .core.entity import JuraEntity, JuraWifiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,20 +84,68 @@ ALERT_SENSORS = [
     },
 ]
 
+# WiFi state-word binary sensors
+_WIFI_STATE_SENSORS = [
+    {
+        "attr": "machine_ready",
+        "display_name": "Machine Ready",
+        "icon": "mdi:coffee-maker-check",
+        "device_class": BinarySensorDeviceClass.RUNNING,
+        "entity_category": None,
+    },
+    {
+        "attr": "water_missing",
+        "display_name": "Water Missing",
+        "icon": "mdi:water-off",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    {
+        "attr": "grinder_empty",
+        "display_name": "Grinder Empty",
+        "icon": "mdi:coffee-off",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    {
+        "attr": "drip_tray_full",
+        "display_name": "Drip Tray Full",
+        "icon": "mdi:tray-alert",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+    {
+        "attr": "grounds_full",
+        "display_name": "Grounds Full",
+        "icon": "mdi:delete-alert",
+        "device_class": BinarySensorDeviceClass.PROBLEM,
+        "entity_category": EntityCategory.DIAGNOSTIC,
+    },
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, add_entities: AddEntitiesCallback
 ):
     device = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Create connection sensor
-    entities: list = [JuraSensor(device, "connection")]
+    if config_entry.data.get("connection_type") == "wifi":
+        entities: list = [JuraWifiConnectivity(device)]
+        for sensor_def in _WIFI_STATE_SENSORS:
+            entities.append(JuraWifiStateBit(device, sensor_def))
+        add_entities(entities)
+        return
 
-    # Create alert binary sensors
+    # BLE path
+    entities = [JuraSensor(device, "connection")]
     for alert_info in ALERT_SENSORS:
         entities.append(JuraAlertBinarySensor(device, alert_info))
-
     add_entities(entities)
+
+
+# ---------------------------------------------------------------------------
+# BLE binary sensor classes (unchanged)
+# ---------------------------------------------------------------------------
 
 
 class JuraSensor(JuraEntity, BinarySensorEntity):
@@ -138,5 +186,41 @@ class JuraAlertBinarySensor(JuraEntity, BinarySensorEntity):
             for _, alert_name in self.device.active_alerts.items()
         )
 
+        if self.hass:
+            self._async_write_ha_state()
+
+
+# ---------------------------------------------------------------------------
+# WiFi binary sensor classes
+# ---------------------------------------------------------------------------
+
+
+class JuraWifiConnectivity(JuraWifiEntity, BinarySensorEntity):
+    """Connectivity sensor for a WiFi Jura machine."""
+
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def internal_update(self):
+        self._attr_is_on = self.device.connected
+        self._attr_extra_state_attributes = self.device.conn_info
+        if self.hass:
+            self._async_write_ha_state()
+
+
+class JuraWifiStateBit(JuraWifiEntity, BinarySensorEntity):
+    """Binary sensor derived from a single bit of the @TM:08 state word."""
+
+    def __init__(self, device, sensor_def: dict):
+        self._state_attr = sensor_def["attr"]
+        super().__init__(device, sensor_def["attr"])
+        self._attr_name = f"{device.name} {sensor_def['display_name']}"
+        self._attr_icon = sensor_def["icon"]
+        self._attr_device_class = sensor_def["device_class"]
+        self._attr_entity_category = sensor_def["entity_category"]
+
+    def internal_update(self):
+        getter = getattr(self.device, self._state_attr, None)
+        self._attr_is_on = getter() if callable(getter) else False
         if self.hass:
             self._async_write_ha_state()

--- a/custom_components/jura/config_flow.py
+++ b/custom_components/jura/config_flow.py
@@ -1,23 +1,142 @@
+"""Config flow for the Jura integration.
+
+Supports two connection types:
+- BLE: existing Bluetooth flow (select MAC from discovered devices)
+- WiFi: UDP auto-discovery + manual IP entry, then auth hash entry
+"""
+
+import asyncio
+import logging
+
 import voluptuous as vol
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigFlow
 
 from .core import DOMAIN
+from .core.discovery import discover_machines
+
+_LOGGER = logging.getLogger(__name__)
+
+CONNECTION_TYPE_BLE = "ble"
+CONNECTION_TYPE_WIFI = "wifi"
+_MANUAL_IP = "manual"
 
 
 class FlowHandler(ConfigFlow, domain=DOMAIN):
-    async def async_step_user(self, user_input=None):
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+    """Handle a Jura config flow."""
 
-        devices = bluetooth.async_get_scanner(self.hass).discovered_devices
-        macs = [v.address for v in devices if v.name == "TT214H BlueFrog"]
+    VERSION = 1
+
+    def __init__(self):
+        self._wifi_host: str = ""
+        self._discovered: list[dict] = []
+
+    async def async_step_user(self, user_input=None):
+        """Step 1: choose BLE or WiFi."""
+        if user_input is not None:
+            conn_type = user_input.get("connection_type", CONNECTION_TYPE_BLE)
+            if conn_type == CONNECTION_TYPE_WIFI:
+                return await self.async_step_wifi_discover()
+            return await self.async_step_ble()
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required("mac"): vol.In(macs),
+                    vol.Required(
+                        "connection_type", default=CONNECTION_TYPE_BLE
+                    ): vol.In([CONNECTION_TYPE_BLE, CONNECTION_TYPE_WIFI])
+                }
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # BLE path (unchanged from original)
+    # ------------------------------------------------------------------
+
+    async def async_step_ble(self, user_input=None):
+        """BLE: pick from discovered Bluetooth devices."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=user_input["mac"],
+                data={"connection_type": CONNECTION_TYPE_BLE, "mac": user_input["mac"]},
+            )
+
+        devices = bluetooth.async_get_scanner(self.hass).discovered_devices
+        macs = [v.address for v in devices if v.name == "TT214H BlueFrog"]
+
+        return self.async_show_form(
+            step_id="ble",
+            data_schema=vol.Schema({vol.Required("mac"): vol.In(macs)}),
+        )
+
+    # ------------------------------------------------------------------
+    # WiFi path
+    # ------------------------------------------------------------------
+
+    async def async_step_wifi_discover(self, user_input=None):
+        """WiFi step 1: run UDP discovery and let the user pick a machine."""
+        if user_input is not None:
+            host = user_input.get("host", _MANUAL_IP)
+            if host == _MANUAL_IP:
+                return await self.async_step_wifi_manual()
+            self._wifi_host = host
+            return await self.async_step_wifi_auth()
+
+        try:
+            self._discovered = await asyncio.wait_for(
+                discover_machines(timeout=5.0), timeout=6.0
+            )
+            _LOGGER.debug("WiFi discovery found %d machine(s)", len(self._discovered))
+        except Exception as e:
+            _LOGGER.warning("WiFi discovery failed: %s", e)
+            self._discovered = []
+
+        host_options: dict[str, str] = {
+            m["ip"]: f"{m.get('name', m['ip'])} ({m['ip']})"
+            for m in self._discovered
+        }
+        host_options[_MANUAL_IP] = "Enter IP address manually"
+
+        return self.async_show_form(
+            step_id="wifi_discover",
+            data_schema=vol.Schema({vol.Required("host"): vol.In(host_options)}),
+        )
+
+    async def async_step_wifi_manual(self, user_input=None):
+        """WiFi step 1b: manually enter machine IP address."""
+        if user_input is not None:
+            self._wifi_host = user_input["host"]
+            return await self.async_step_wifi_auth()
+
+        return self.async_show_form(
+            step_id="wifi_manual",
+            data_schema=vol.Schema({vol.Required("host"): str}),
+        )
+
+    async def async_step_wifi_auth(self, user_input=None):
+        """WiFi step 2: enter auth credentials (auth hash from J.O.E. app pairing)."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Jura WiFi ({self._wifi_host})",
+                data={
+                    "connection_type": CONNECTION_TYPE_WIFI,
+                    "host": self._wifi_host,
+                    "port": user_input.get("port", 51515),
+                    "pin": user_input.get("pin", ""),
+                    "auth_hash": user_input.get("auth_hash", ""),
+                    "device_name": user_input.get("device_name", "HomeAssistant"),
+                },
+            )
+
+        return self.async_show_form(
+            step_id="wifi_auth",
+            data_schema=vol.Schema(
+                {
+                    vol.Required("auth_hash"): str,
+                    vol.Optional("pin", default=""): str,
+                    vol.Optional("device_name", default="HomeAssistant"): str,
+                    vol.Optional("port", default=51515): int,
                 }
             ),
         )

--- a/custom_components/jura/core/discovery.py
+++ b/custom_components/jura/core/discovery.py
@@ -1,0 +1,95 @@
+"""UDP discovery for Jura WiFi Connect machines.
+
+Jura machines with the WiFi Connect module broadcast a 117-byte UDP beacon
+every ~60 seconds to the subnet broadcast address on port 51515.
+"""
+
+import asyncio
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY_PORT = 51515
+BEACON_SIZE = 117
+
+
+def parse_beacon(data: bytes) -> dict | None:
+    """Parse a 117-byte Jura UDP discovery beacon.
+
+    The beacon contains null-terminated UTF-8/latin-1 strings for device name,
+    model, and other fields. A 6-byte MAC address is embedded at a fixed offset.
+    """
+    if len(data) != BEACON_SIZE:
+        return None
+    try:
+        text = data.decode("latin-1", errors="replace")
+        fields = [f.strip() for f in text.split("\x00") if f.strip()]
+        result: dict = {"raw": data.hex()}
+        if len(fields) >= 1:
+            result["name"] = fields[0]
+        if len(fields) >= 2:
+            result["model"] = fields[1]
+        # MAC address is typically embedded at offset 6–12 in the beacon
+        mac_bytes = data[6:12]
+        result["mac"] = ":".join(f"{b:02X}" for b in mac_bytes)
+        return result
+    except Exception as e:
+        _LOGGER.debug("Error parsing beacon: %s", e)
+        return None
+
+
+class _JuraDiscoveryProtocol(asyncio.DatagramProtocol):
+    """asyncio UDP protocol that fires a callback for each valid Jura beacon."""
+
+    def __init__(self, callback):
+        self.callback = callback
+        self.transport = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+
+    def datagram_received(self, data, addr):
+        _LOGGER.debug(
+            "UDP datagram from %s, length=%d", addr[0], len(data)
+        )
+        if len(data) == BEACON_SIZE:
+            machine = parse_beacon(data)
+            if machine:
+                machine["ip"] = addr[0]
+                self.callback(machine)
+
+    def error_received(self, exc):
+        _LOGGER.debug("Discovery socket error: %s", exc)
+
+
+async def discover_machines(timeout: float = 5.0) -> list[dict]:
+    """Listen for Jura WiFi beacons and return discovered machines.
+
+    Opens a UDP socket on port 51515, waits *timeout* seconds, then closes it.
+    Returns a list of machine dicts with keys: ip, mac, name, model, raw.
+    """
+    machines: dict[str, dict] = {}
+
+    def on_machine(machine: dict):
+        key = machine.get("mac") or machine.get("ip", "")
+        machines[key] = machine
+
+    loop = asyncio.get_event_loop()
+    try:
+        transport, _ = await loop.create_datagram_endpoint(
+            lambda: _JuraDiscoveryProtocol(on_machine),
+            local_addr=("0.0.0.0", DISCOVERY_PORT),
+            allow_broadcast=True,
+        )
+    except OSError as e:
+        _LOGGER.warning(
+            "Cannot bind UDP port %d for discovery: %s", DISCOVERY_PORT, e
+        )
+        return []
+
+    try:
+        await asyncio.sleep(timeout)
+    finally:
+        transport.close()
+
+    return list(machines.values())

--- a/custom_components/jura/core/entity.py
+++ b/custom_components/jura/core/entity.py
@@ -39,3 +39,38 @@ class JuraEntity(Entity):
 
     async def async_update(self):
         self.device.client.ping()
+
+
+class JuraWifiEntity(Entity):
+    """Base entity for Jura machines connected via WiFi."""
+
+    _attr_should_poll = False
+
+    def __init__(self, device, attr: str):
+        self.device = device
+        self.attr = attr
+
+        mac_clean = re.sub(r"[^0-9a-zA-Z]", "", device.mac)
+
+        # Only register MAC connection if we have a real colon-separated MAC
+        connections = (
+            {(CONNECTION_NETWORK_MAC, device.mac)} if ":" in device.mac else set()
+        )
+        self._attr_device_info = DeviceInfo(
+            connections=connections,
+            identifiers={(DOMAIN, device.mac)},
+            manufacturer="Jura",
+            model=device.model,
+            name=device.name or "Jura",
+        )
+        self._attr_name = device.name + " " + attr.replace("_", " ").title()
+        self._attr_unique_id = mac_clean + "_wifi_" + attr
+
+        self.entity_id = DOMAIN + "." + sanitize(self._attr_unique_id)
+
+        self.internal_update()
+
+        device.register_wifi_update(self.internal_update)
+
+    def internal_update(self):
+        pass

--- a/custom_components/jura/core/wifi_client.py
+++ b/custom_components/jura/core/wifi_client.py
@@ -1,0 +1,129 @@
+"""Async TCP client for Jura WiFi Connect module (port 51515)."""
+
+import asyncio
+import logging
+
+from .wifi_encryption import wifi_make_frame, wifi_parse_frame
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WifiClient:
+    """Async WiFi client for Jura machines via plain TCP on port 51515."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 51515,
+        pin: str = "",
+        device_name: str = "HomeAssistant",
+        auth_hash: str = "",
+    ):
+        self.host = host
+        self.port = port
+        self.pin = pin
+        self.device_name_hex = device_name.encode().hex()
+        self.auth_hash = auth_hash
+        self.reader: asyncio.StreamReader | None = None
+        self.writer: asyncio.StreamWriter | None = None
+        self.connected = False
+
+    async def connect(self) -> bool:
+        """Open TCP connection and authenticate with the machine.
+
+        Returns True if auth succeeded (@hp4 response), False otherwise.
+        """
+        try:
+            self.reader, self.writer = await asyncio.open_connection(
+                self.host, self.port
+            )
+        except OSError as e:
+            _LOGGER.warning("WiFi connect to %s:%s failed: %s", self.host, self.port, e)
+            return False
+
+        auth_cmd = f"@HP:{self.pin},{self.device_name_hex},{self.auth_hash}"
+        await self._send_frame(auth_cmd)
+        response = await self.read_response()
+        _LOGGER.debug("Auth response: %r", response)
+        self.connected = "@hp4" in response
+        if not self.connected:
+            _LOGGER.warning(
+                "WiFi auth failed for %s, response: %r", self.host, response
+            )
+        return self.connected
+
+    async def _send_frame(self, cmd: str):
+        """Encode and write one framed command."""
+        frame = wifi_make_frame(cmd)
+        self.writer.write(frame)
+        await self.writer.drain()
+
+    async def send_command(self, cmd: str, timeout: float = 3.0) -> str:
+        """Send command string and wait for one response frame."""
+        await self._send_frame(cmd)
+        return await self.read_response(timeout)
+
+    async def read_response(self, timeout: float = 3.0) -> str:
+        """Read and decode one response frame from the machine."""
+        try:
+            data = await asyncio.wait_for(self._read_until_frame(), timeout)
+            return wifi_parse_frame(data)
+        except asyncio.TimeoutError:
+            _LOGGER.debug("Read timeout waiting for response from %s", self.host)
+            return ""
+
+    async def _read_until_frame(self) -> bytes:
+        """Read raw bytes until the 0x0D 0x0A frame terminator."""
+        buf = bytearray()
+        while True:
+            byte = await self.reader.read(1)
+            if not byte:
+                break
+            buf.extend(byte)
+            if len(buf) >= 2 and buf[-2] == 0x0D and buf[-1] == 0x0A:
+                break
+        return bytes(buf)
+
+    async def get_machine_state(self) -> int:
+        """Return the 32-bit machine state word from @TM:08."""
+        await self.send_command("@TS:01")
+        resp = await self.send_command("@TM:08")
+        await self.send_command("@TS:00")
+        if resp.startswith("@tm:08,"):
+            try:
+                return int(resp[7:].strip(), 16)
+            except ValueError:
+                _LOGGER.debug("Could not parse state word from: %r", resp)
+        return 0
+
+    async def get_firmware_version(self) -> str:
+        """Return firmware version string from @TG:C0."""
+        resp = await self.send_command("@TG:C0")
+        if resp.startswith("@tg:"):
+            return resp[4:].strip()
+        return ""
+
+    async def get_temperature(self) -> int | None:
+        """Return raw temperature value from @TM:0A, or None on failure."""
+        await self.send_command("@TS:01")
+        resp = await self.send_command("@TM:0A")
+        await self.send_command("@TS:00")
+        resp_lower = resp.lower()
+        if resp_lower.startswith("@tm:0a,"):
+            try:
+                return int(resp_lower[7:].strip(), 16)
+            except ValueError:
+                _LOGGER.debug("Could not parse temperature from: %r", resp)
+        return None
+
+    async def disconnect(self):
+        """Close the TCP connection cleanly."""
+        self.connected = False
+        if self.writer:
+            try:
+                self.writer.close()
+                await self.writer.wait_closed()
+            except Exception:
+                pass
+            self.writer = None
+            self.reader = None

--- a/custom_components/jura/core/wifi_device.py
+++ b/custom_components/jura/core/wifi_device.py
@@ -1,0 +1,148 @@
+"""WiFi-connected Jura machine device model.
+
+Wraps WifiClient and provides polling + update-callback infrastructure
+compatible with the JuraWifiEntity base class.
+
+Machine state word (@TM:08) bit definitions:
+    Bit 0 (0x01): standby / idle
+    Bit 1 (0x02): ready
+    Bit 2 (0x04): machine ready (heating done, brew-ready)
+    Bit 3 (0x08): water tank missing / empty
+    Bit 4 (0x10): grinder empty (no beans)
+    Bit 5 (0x20): drip tray full
+    Bit 6 (0x40): grounds container full
+"""
+
+import logging
+from typing import Callable
+
+from .wifi_client import WifiClient
+
+_LOGGER = logging.getLogger(__name__)
+
+# Bit masks for the @TM:08 state word
+BIT_STANDBY = 0x01
+BIT_READY = 0x02
+BIT_MACHINE_READY = 0x04
+BIT_WATER_MISSING = 0x08
+BIT_GRINDER_EMPTY = 0x10
+BIT_DRIP_TRAY_FULL = 0x20
+BIT_GROUNDS_FULL = 0x40
+
+
+class WifiDevice:
+    """Represents a Jura coffee machine reachable over TCP/IP (WiFi Connect)."""
+
+    def __init__(
+        self,
+        name: str,
+        host: str,
+        port: int = 51515,
+        pin: str = "",
+        device_name: str = "HomeAssistant",
+        auth_hash: str = "",
+        model: str = "Jura WiFi",
+        mac: str = "",
+    ):
+        self.name = name
+        self.model = model
+        self.connected = False
+        self.conn_info: dict = {"host": host}
+
+        # Use MAC if provided; otherwise derive a stable ID from the IP
+        self._mac = mac if mac else host.replace(".", "")
+
+        self._client = WifiClient(host, port, pin, device_name, auth_hash)
+
+        self._state_word: int = 0
+        self._firmware_version: str = ""
+        self._temperature: int | None = None
+
+        self._update_handlers: list[Callable] = []
+
+    # --- Public properties ---------------------------------------------------
+
+    @property
+    def mac(self) -> str:
+        """Stable device identifier (real MAC or IP-derived string)."""
+        return self._mac
+
+    @property
+    def state_word(self) -> int:
+        """Raw 32-bit machine state word from @TM:08."""
+        return self._state_word
+
+    @property
+    def firmware_version(self) -> str:
+        """WiFi firmware version string from @TG:C0."""
+        return self._firmware_version
+
+    @property
+    def temperature(self) -> int | None:
+        """Raw temperature value from @TM:0A (unit depends on machine)."""
+        return self._temperature
+
+    # --- State-word helpers --------------------------------------------------
+
+    def machine_ready(self) -> bool:
+        return bool(self._state_word & BIT_MACHINE_READY)
+
+    def water_missing(self) -> bool:
+        return bool(self._state_word & BIT_WATER_MISSING)
+
+    def grinder_empty(self) -> bool:
+        return bool(self._state_word & BIT_GRINDER_EMPTY)
+
+    def drip_tray_full(self) -> bool:
+        return bool(self._state_word & BIT_DRIP_TRAY_FULL)
+
+    def grounds_full(self) -> bool:
+        return bool(self._state_word & BIT_GROUNDS_FULL)
+
+    # --- Update handler registration -----------------------------------------
+
+    def register_wifi_update(self, handler: Callable):
+        """Register a callback invoked after each poll cycle completes."""
+        self._update_handlers.append(handler)
+
+    def _notify_updates(self):
+        for handler in self._update_handlers:
+            try:
+                handler()
+            except Exception as e:
+                _LOGGER.warning("Update handler raised an exception: %s", e)
+
+    # --- Polling -------------------------------------------------------------
+
+    async def async_update(self):
+        """Poll the machine for current state. Called by the HA coordinator."""
+        try:
+            if not self._client.connected:
+                ok = await self._client.connect()
+                if not ok:
+                    self.connected = False
+                    self._notify_updates()
+                    return
+
+            self.connected = True
+            self._state_word = await self._client.get_machine_state()
+            self.conn_info["state_word"] = hex(self._state_word)
+
+            if not self._firmware_version:
+                self._firmware_version = await self._client.get_firmware_version()
+
+            temp = await self._client.get_temperature()
+            if temp is not None:
+                self._temperature = temp
+
+        except Exception as e:
+            _LOGGER.warning("WiFi poll error for %s: %s", self.name, e)
+            self.connected = False
+            await self._client.disconnect()
+
+        self._notify_updates()
+
+    async def disconnect(self):
+        """Disconnect from the machine (called on HA unload)."""
+        await self._client.disconnect()
+        self.connected = False

--- a/custom_components/jura/core/wifi_encryption.py
+++ b/custom_components/jura/core/wifi_encryption.py
@@ -1,0 +1,96 @@
+"""WiFi-specific encryption for Jura machines (TCP 51515 protocol).
+
+The WiFi protocol reuses the same shuffle/S-box from BLE encryption but adds:
+- Per-frame random key byte prepended to the payload
+- ESC encoding for reserved bytes (0x00, 0x0A, 0x0D, 0x26, 0x1B)
+- Frame format: 0x2A + key_byte + encoded_payload + 0x0D 0x0A
+"""
+
+import random
+
+from .encryption import shuffle
+
+ESCAPED_CHARS = [0x00, 0x0A, 0x0D, 0x26, 0x1B]
+
+
+def wifi_encode(key: int, data: bytes) -> bytes:
+    """Encode data for WiFi transmission with key byte and ESC escaping."""
+    out = bytearray()
+    key1 = key >> 4
+    key2 = key & 0xF
+    kb = key & 0xFF
+    if kb in ESCAPED_CHARS:
+        out += bytes([0x1B, (kb ^ 0x80) & 0xFF])
+    else:
+        out.append(kb)
+    cnt = 0
+    for byte in data:
+        src1 = (byte >> 4) & 0xF
+        src2 = byte & 0xF
+        dst1 = shuffle(src1, cnt, key1, key2)
+        cnt += 1
+        dst2 = shuffle(src2, cnt, key1, key2)
+        cnt += 1
+        m = ((dst1 << 4) | dst2) & 0xFF
+        if m in ESCAPED_CHARS:
+            out += bytes([0x1B, (m ^ 0x80) & 0xFF])
+        else:
+            out.append(m)
+    return bytes(out)
+
+
+def wifi_decode(buf: bytes) -> str:
+    """Decode a received WiFi payload (0x2A prefix already stripped).
+
+    Handles ESC sequences, extracts key from first byte, returns decoded string.
+    """
+    if len(buf) < 2:
+        return ""
+    idx = 0
+    b = buf[idx]
+    if b == 0x1B:
+        key = (buf[idx + 1] ^ 0x80) & 0xFF
+        idx = 2
+    else:
+        key = b
+        idx = 1
+    key1 = key >> 4
+    key2 = key & 0xF
+    result = bytearray()
+    cnt = 0
+    while idx < len(buf):
+        c = buf[idx]
+        if c == 0x0D:
+            break
+        if c == 0x1B:
+            idx += 1
+            if idx >= len(buf):
+                break
+            c = (buf[idx] ^ 0x80) & 0xFF
+        dl = shuffle((c >> 4) & 0xF, cnt, key1, key2)
+        cnt += 1
+        dr = shuffle(c & 0xF, cnt, key1, key2)
+        cnt += 1
+        result.append((dl << 4) | dr)
+        idx += 1
+    return result.decode("utf-8", errors="replace")
+
+
+def wifi_make_frame(cmd: str) -> bytes:
+    """Create a complete WiFi frame for sending.
+
+    Format: 0x2A + wifi_encode(random_key, cmd) + 0x0D 0x0A
+    Key nibbles 0xE and 0xF are avoided to prevent decode issues.
+    """
+    while True:
+        key = random.randint(0, 255)
+        if (key & 0xF) not in (0xE, 0xF):
+            break
+    return bytes([0x2A]) + wifi_encode(key, cmd.encode()) + bytes([0x0D, 0x0A])
+
+
+def wifi_parse_frame(raw: bytes) -> str:
+    """Parse a received raw frame including its 0x2A prefix."""
+    if not raw or raw[0] != 0x2A:
+        return ""
+    return wifi_decode(raw[1:])

--- a/custom_components/jura/sensor.py
+++ b/custom_components/jura/sensor.py
@@ -10,12 +10,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
 from .core import DOMAIN
-from .core.entity import JuraEntity
+from .core.entity import JuraEntity, JuraWifiEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,21 +27,27 @@ async def async_setup_entry(
     """Set up Jura sensor based on a config entry."""
     device = hass.data[DOMAIN][entry.entry_id]
 
-    # Create the total coffees sensor
-    entities: list = [JuraTotalCoffeeSensor(device)]
+    if entry.data.get("connection_type") == "wifi":
+        entities: list = [
+            JuraWifiMachineStateSensor(device),
+            JuraWifiFirmwareSensor(device),
+            JuraWifiTemperatureSensor(device),
+        ]
+        async_add_entities(entities)
+        return
 
-    # Create sensors for each product
+    # BLE path (unchanged)
+    entities = [JuraTotalCoffeeSensor(device)]
+
     for product in device.products:
         product_name = product["@Name"]
         if product.get("@Active") != "false":
             entities.append(JuraProductCountSensor(device, product_name))
 
-    # Create alert sensors
     entities.append(JuraAlertSensor(device))
 
     async_add_entities(entities)
 
-    # Set up automatic refresh
     update_interval = hass.data[DOMAIN].get("update_interval", 60)
 
     async def refresh_statistics(*_):
@@ -52,15 +59,18 @@ async def async_setup_entry(
             # we log as info as this is expected if the device is off
             _LOGGER.info(f"Error refreshing statistics: {ex}")
 
-    # Schedule regular updates
     entry.async_on_unload(
         async_track_time_interval(
             hass, refresh_statistics, timedelta(seconds=update_interval)
         )
     )
 
-    # Do an initial refresh
     hass.async_create_task(refresh_statistics())
+
+
+# ---------------------------------------------------------------------------
+# BLE sensor classes (unchanged)
+# ---------------------------------------------------------------------------
 
 
 class JuraStatisticsSensor(JuraEntity, SensorEntity):
@@ -167,4 +177,68 @@ class JuraAlertSensor(JuraEntity, SensorEntity):
         """Override parent method to ensure alerts are refreshed."""
         _LOGGER.debug(f"Updating alert sensor {self._attr_name}")
         if self.hass is not None:
+            self.async_write_ha_state()
+
+
+# ---------------------------------------------------------------------------
+# WiFi sensor classes
+# ---------------------------------------------------------------------------
+
+
+class JuraWifiMachineStateSensor(JuraWifiEntity, SensorEntity):
+    """Sensor reporting the raw @TM:08 machine state word as hex string."""
+
+    _attr_icon = "mdi:state-machine"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, device):
+        super().__init__(device, "machine_state")
+        self._attr_name = f"{device.name} Machine State"
+
+    @property
+    def native_value(self) -> str | None:
+        sw = self.device.state_word
+        return hex(sw) if self.device.connected else None
+
+    def internal_update(self):
+        if self.hass:
+            self.async_write_ha_state()
+
+
+class JuraWifiFirmwareSensor(JuraWifiEntity, SensorEntity):
+    """Sensor reporting the WiFi firmware version string."""
+
+    _attr_icon = "mdi:chip"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, device):
+        super().__init__(device, "firmware_version")
+        self._attr_name = f"{device.name} Firmware Version"
+
+    @property
+    def native_value(self) -> str | None:
+        fw = self.device.firmware_version
+        return fw if fw else None
+
+    def internal_update(self):
+        if self.hass:
+            self.async_write_ha_state()
+
+
+class JuraWifiTemperatureSensor(JuraWifiEntity, SensorEntity):
+    """Sensor reporting raw temperature from @TM:0A."""
+
+    _attr_icon = "mdi:thermometer"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, device):
+        super().__init__(device, "temperature")
+        self._attr_name = f"{device.name} Temperature"
+
+    @property
+    def native_value(self) -> int | None:
+        return self.device.temperature
+
+    def internal_update(self):
+        if self.hass:
             self.async_write_ha_state()

--- a/custom_components/jura/translations/en.json
+++ b/custom_components/jura/translations/en.json
@@ -2,8 +2,38 @@
   "config": {
     "step": {
       "user": {
+        "title": "Choose Connection Type",
         "data": {
-          "mac": "MAC"
+          "connection_type": "Connection Type"
+        }
+      },
+      "ble": {
+        "title": "Select Bluetooth Device",
+        "data": {
+          "mac": "MAC Address"
+        }
+      },
+      "wifi_discover": {
+        "title": "Discover Jura WiFi Machines",
+        "description": "Scanning for Jura machines on the network. Select a discovered machine or choose to enter an IP address manually.",
+        "data": {
+          "host": "Machine"
+        }
+      },
+      "wifi_manual": {
+        "title": "Enter Machine IP Address",
+        "data": {
+          "host": "IP Address"
+        }
+      },
+      "wifi_auth": {
+        "title": "WiFi Authentication",
+        "description": "Enter the auth hash from your J.O.E. app pairing. Leave PIN empty if not required.",
+        "data": {
+          "auth_hash": "Auth Hash",
+          "pin": "PIN (optional)",
+          "device_name": "Device Name",
+          "port": "Port"
         }
       }
     }


### PR DESCRIPTION
New modules:
- core/wifi_encryption.py: nibble cipher with ESC encoding and per-frame random key, reusing the existing shuffle() S-box from BLE encryption
- core/wifi_client.py: async TCP client for T-protocol commands (@TM:08, @TS:01/00, @TG:C0, @TM:0A, @HP auth)
- core/discovery.py: asyncio UDP listener for 117-byte Jura beacons on port 51515 (broadcast auto-discovery)
- core/wifi_device.py: WifiDevice model with 30-second polling, state-word bit helpers, and update-callback infrastructure

Updated:
- config_flow.py: choose BLE or WiFi; WiFi path runs UDP discovery or accepts manual IP, then collects auth hash / PIN / device name
- __init__.py: route WiFi entries through WifiDevice setup + polling; BLE path unchanged
- binary_sensor.py: JuraWifiConnectivity + JuraWifiStateBit for machine_ready, water_missing, grinder_empty, drip_tray_full, grounds_full
- sensor.py: JuraWifiMachineStateSensor, JuraWifiFirmwareSensor, JuraWifiTemperatureSensor
- core/entity.py: JuraWifiEntity base class (no BLE ping, WiFi callbacks)
- translations/en.json: labels for all new config flow steps