### PR TITLE
Fix entity ID wrong domain warning

### DIFF
--- a/custom_components/jura/core/entity.py
+++ b/custom_components/jura/core/entity.py
@@ -1,8 +1,14 @@
+import re
+
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from . import DOMAIN
 from .device import Device
+
+
+def sanitize(entity_id: str) -> str:
+    return re.sub(r"[^0-9a-z_]+", "", entity_id.lower())
 
 
 class JuraEntity(Entity):
@@ -25,6 +31,10 @@ class JuraEntity(Entity):
         self.internal_update()
 
         device.register_update(attr, self.internal_update)
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        return sanitize(self.unique_id)
 
     def internal_update(self):
         pass

--- a/custom_components/jura/core/entity.py
+++ b/custom_components/jura/core/entity.py
@@ -1,14 +1,8 @@
-import re
-
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from . import DOMAIN
 from .device import Device
-
-
-def sanitize(entity_id: str) -> str:
-    return re.sub(r"[^0-9a-z_]+", "", entity_id.lower())
 
 
 class JuraEntity(Entity):
@@ -27,8 +21,6 @@ class JuraEntity(Entity):
         )
         self._attr_name = device.name + " " + attr.replace("_", " ").title()
         self._attr_unique_id = device.mac.replace(":", "") + "_" + attr
-
-        self.entity_id = DOMAIN + "." + sanitize(self._attr_unique_id)
 
         self.internal_update()
 


### PR DESCRIPTION
## Summary

- Removes the explicit `self.entity_id` assignment in `JuraEntity.__init__` that hardcoded the `jura.` domain prefix for all entities regardless of platform
- Home Assistant now auto-generates correct entity IDs (`sensor.`, `binary_sensor.`, `button.`, etc.) from `_attr_unique_id`
- Although the message "Detected that custom integration 'jura' sets an entity ID with wrong domain" I didn't have any 'jura.*' entities, so I think HA was fixing it. This should mean this change won't affect and automations.

Fixes #66

## Test plan

- [x] Verify no "sets an entity ID with wrong domain" warnings appear in HA logs after update
- [x] Confirm sensor, binary_sensor, and button entities are accessible with correct domain prefixes

Generated with [Claude Code](https://claude.com/claude-code)